### PR TITLE
extend react-app configuration as new standard

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016-present, Kingsquare BV.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # eslint-config-kingsquare
 
-This is the basic eslint config used by kingsquare.
+This is the basic eslint config used by Kingsquare BV.
+
+This version extends the [`react-app`](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/README.md) standard
 
 To install and use do the following:
 
 ```
-yarn add --dev eslint eslint-config-kingsquare prettier
+yarn add eslint-config-kingsquare --dev
 ```
-also create a .eslintrc.json:
+
+and add the following eslint configuration:
+
 ```json
 {
-  "extends": "kingsquare",
-  "env": {
-    "browser": true,
-    "node": true
-  }
+  "extends": "kingsquare"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,21 +1,8 @@
 module.exports = {
-  "extends": ["eslint:recommended", "plugin:react/recommended", "plugin:prettier/recommended"],
-  "parser": "babel-eslint",
-  "parserOptions": {
-    "sourceType": "module",
-    "ecmaVersion": 2017,
-    "ecmaFeatures": {
-      "jsx": true
-    }
-  },
+  "extends": ["react-app", "plugin:prettier/recommended"],
   "plugins": [
-    "react",
     "prettier"
   ],
-  "env": {
-    "es6": true,
-    "node": true
-  },
   "rules": {
     "prettier/prettier": "error",
     "no-var": "error",

--- a/index.js
+++ b/index.js
@@ -17,6 +17,15 @@ module.exports = {
     "node": true
   },
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-var": "error",
+    "prefer-const": "error",
+    "prefer-destructuring": "error",
+    "prefer-spread": "error",
+    "prefer-template": "error",
+    "prefer-arrow-callback": "error",
+    "arrow-body-style": "error",
+    "prefer-promise-reject-errors": "error",
+    "prefer-rest-params": "error"
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,20 +1,35 @@
 {
   "name": "@kingsquare/eslint-config",
-  "version": "5.0.4",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "dependencies": {
-    "babel-eslint": "^10.0.1",
-    "eslint-config-prettier": "^3.3.0",
-    "eslint-plugin-prettier": "^3.0.0",
-    "eslint-plugin-react": "^7.11.1"
-  },
+  "version": "6.0.0",
+  "description": "ESLint configuration used by Kingsquare BV",
   "author": "Kingsquare BV",
-  "license": "ISC",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kingsquare/eslint-config-kingsquare.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kingsquare/eslint-config-kingsquare/issues"
+  },
+  "files": [
+    "index.js"
+  ],
+  "main": "index.js",
+  "dependencies": {
+    "eslint-config-react-app": "^5.0.2",
+    "@typescript-eslint/eslint-plugin": "2.x",
+    "@typescript-eslint/parser": "2.x",
+    "babel-eslint": "10.x",
+    "eslint": "6.x",
+    "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-flowtype": "3.x",
+    "eslint-plugin-import": "2.x",
+    "eslint-plugin-jsx-a11y": "6.x",
+    "eslint-plugin-react": "7.x",
+    "eslint-plugin-react-hooks": "1.x",
+    "prettier": "^1.18.2"
+  },
   "peerDependencies": {
-    "eslint": "^5.8.0"
   }
 }


### PR DESCRIPTION
Extend `react-app` configuration as new upstream standard (our new version 6.0.0). This standard is based on the airbnb standard (though less opinionated). As the previous kingsquare standard also was based. 

* extends [`eslint-config-react-app`](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/README.md) [see also the configuration](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/index.js)
  * supports typescript linting instead of requiring and extra tslint

Extras
* all necessary `peerDependencies` are installed alongside this package (as `dependencies`) removing the need for adding them separately
* out of the box prettier
* a few extra rules (WIP)

Note this PR removes the need for the previous PRs, though may be nice to still use them for previous versions. 

 * https://github.com/kingsquare/eslint-config-kingsquare/pull/3 _could still be pulled and merged into the current, before this PR_
 * https://github.com/kingsquare/eslint-config-kingsquare/pull/4 _could still be pulled and merged into the current, before this PR_
 